### PR TITLE
Persist theme selection across pages

### DIFF
--- a/__tests__/eateries.test.js
+++ b/__tests__/eateries.test.js
@@ -6,7 +6,7 @@ describe('eateries.html', () => {
   let window, document;
   beforeAll(async () => {
     const html = fs.readFileSync(path.join(__dirname, '..', 'eateries.html'), 'utf8');
-    const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable' });
+    const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
     await new Promise(r => dom.window.addEventListener('load', r));
     window = dom.window;
     document = window.document;
@@ -32,5 +32,19 @@ describe('eateries.html', () => {
   test('table rows contain no script elements', () => {
     const scripts = document.querySelectorAll('#eatery-table tbody script');
     expect(scripts.length).toBe(0);
+  });
+
+  test('applies stored theme on load', async () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'eateries.html'), 'utf8');
+    const dom2 = new JSDOM(html, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      url: 'http://localhost',
+      beforeParse(window) {
+        window.localStorage.setItem('theme', 'dark');
+      }
+    });
+    await new Promise(r => dom2.window.addEventListener('load', r));
+    expect(dom2.window.document.body.classList.contains('dark')).toBe(true);
   });
 });

--- a/__tests__/guide.test.js
+++ b/__tests__/guide.test.js
@@ -6,7 +6,7 @@ describe('guide.html', () => {
   let document;
   beforeAll(() => {
     const html = fs.readFileSync(path.join(__dirname, '..', 'guide.html'), 'utf8');
-    const dom = new JSDOM(html, { runScripts: 'dangerously' });
+    const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
     document = dom.window.document;
   });
 
@@ -21,5 +21,18 @@ describe('guide.html', () => {
     const btn = document.getElementById('theme-toggle');
     btn.click();
     expect(document.body.classList.contains('dark')).toBe(true);
+  });
+
+  test('applies stored theme on load', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'guide.html'), 'utf8');
+    const dom2 = new JSDOM(html, {
+      runScripts: 'dangerously',
+      url: 'http://localhost',
+      beforeParse(window) {
+        window.localStorage.setItem('theme', 'dark');
+      }
+    });
+    const doc2 = dom2.window.document;
+    expect(doc2.body.classList.contains('dark')).toBe(true);
   });
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -6,7 +6,7 @@ describe('index.html', () => {
   let dom, document, window;
   beforeAll(async () => {
     const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
-    dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable' });
+    dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
     await new Promise(r => {
       dom.window.addEventListener('load', r);
     });
@@ -32,6 +32,20 @@ describe('index.html', () => {
     expect(document.body.classList.contains('dark')).toBe(true);
     btn.click();
     expect(document.body.classList.contains('dark')).toBe(false);
+  });
+
+  test('applies stored theme on load', async () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+    const dom2 = new JSDOM(html, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      url: 'http://localhost',
+      beforeParse(window) {
+        window.localStorage.setItem('theme', 'dark');
+      }
+    });
+    await new Promise(r => dom2.window.addEventListener('load', r));
+    expect(dom2.window.document.body.classList.contains('dark')).toBe(true);
   });
 
   test('countWeekends calculates correctly', () => {

--- a/eateries.html
+++ b/eateries.html
@@ -135,8 +135,17 @@
             }
         }
 
+        function applyStoredTheme() {
+            const stored = localStorage.getItem('theme');
+            if (stored === 'dark') {
+                document.body.classList.add('dark');
+            }
+        }
+
         themeToggle.addEventListener('click', () => {
             document.body.classList.toggle('dark');
+            const theme = document.body.classList.contains('dark') ? 'dark' : 'light';
+            localStorage.setItem('theme', theme);
             updateToggleText();
         });
 
@@ -168,6 +177,7 @@
         holeFilter.addEventListener('change', renderList);
         takeoutFilter.addEventListener('change', renderList);
 
+        applyStoredTheme();
         updateToggleText();
         renderList();
     </script>

--- a/guide.html
+++ b/guide.html
@@ -71,10 +71,20 @@
                 themeToggle.textContent = 'Dark Mode';
             }
         }
+
+        function applyStoredTheme() {
+            const stored = localStorage.getItem('theme');
+            if (stored === 'dark') {
+                document.body.classList.add('dark');
+            }
+        }
         themeToggle.addEventListener('click', () => {
             document.body.classList.toggle('dark');
+            const theme = document.body.classList.contains('dark') ? 'dark' : 'light';
+            localStorage.setItem('theme', theme);
             updateToggleText();
         });
+        applyStoredTheme();
         updateToggleText();
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -134,11 +134,21 @@
             }
         }
 
+        function applyStoredTheme() {
+            const stored = localStorage.getItem('theme');
+            if (stored === 'dark') {
+                document.body.classList.add('dark');
+            }
+        }
+
         themeToggle.addEventListener('click', () => {
             document.body.classList.toggle('dark');
+            const theme = document.body.classList.contains('dark') ? 'dark' : 'light';
+            localStorage.setItem('theme', theme);
             updateToggleText();
         });
 
+        applyStoredTheme();
         updateToggleText();
 
         updateCountdown();


### PR DESCRIPTION
## Summary
- persist dark/light theme via localStorage
- apply stored theme on page load
- verify theme persistence with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459c74f7c483259755d56b612e5d98