### PR TITLE
Add navigation and dark mode

### DIFF
--- a/eateries.html
+++ b/eateries.html
@@ -9,10 +9,21 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        :root {
+            --bg-color: #FDFBF8;
+            --text-color: #4A4A4A;
+            --accent-color: #D66A55;
+        }
+        .dark {
+            --bg-color: #1a1a1a;
+            --text-color: #f0f0f0;
+            --accent-color: #ff8866;
+        }
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #FDFBF8;
-            color: #4A4A4A;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            padding-top: 70px;
         }
         .chart-container {
             position: relative;
@@ -93,12 +104,47 @@
             text-decoration: none;
             cursor: pointer;
         }
+        header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            background-color: var(--bg-color);
+            padding: 1rem;
+            display: flex;
+            align-items: center;
+            z-index: 1000;
+        }
+        nav {
+            flex: 1;
+            text-align: center;
+        }
+        nav a {
+            margin: 0 0.5rem;
+            color: var(--text-color);
+            text-decoration: none;
+        }
+        #theme-toggle {
+            padding: 0.5rem 1rem;
+            font-size: 1rem;
+            cursor: pointer;
+            background-color: var(--accent-color);
+            border: none;
+            color: var(--bg-color);
+            border-radius: 4px;
+        }
     </style>
 </head>
 <body class="antialiased">
 
 <div id="app" class="container mx-auto p-4 md:p-8">
     <header class="text-center mb-10">
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="guide.html">2025 Guide</a>
+            <a href="eateries.html">Top Eateries</a>
+        </nav>
+        <button id="theme-toggle" class="ml-2">Dark Mode</button>
         <h1 class="text-4xl md:text-5xl font-bold text-gray-800 mb-2">Chicago's Culinary Scene</h1>
         <p class="text-lg text-gray-600">An Interactive Guide to the City's Top Eateries</p>
         <button id="open-full-report-btn" class="mt-4 px-6 py-2 bg-slate-700 text-white rounded-full text-md font-medium hover:bg-slate-800 transition">Read the Full Culinary Report</button>
@@ -323,6 +369,24 @@ function updateCuisineChart(data){
     if(cuisineChart){cuisineChart.data.labels=labels;cuisineChart.data.datasets[0].data=chartData;cuisineChart.data.datasets[0].backgroundColor=bg;cuisineChart.update();}
     else{const ctx=document.getElementById('cuisineChart').getContext('2d');cuisineChart=new Chart(ctx,{type:'bar',data:{labels:labels,datasets:[{label:'Number of Restaurants',data:chartData,backgroundColor:bg,borderColor:'#4B5563',borderWidth:1}]},options:{indexAxis:'y',responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{beginAtZero:true,ticks:{stepSize:1}}}}});}
 }
+
+const themeToggle=document.getElementById('theme-toggle');
+function updateToggleText(){
+    if(document.body.classList.contains('dark')) themeToggle.textContent='Light Mode';
+    else themeToggle.textContent='Dark Mode';
+}
+function applyStoredTheme(){
+    const stored=localStorage.getItem('theme');
+    if(stored==='dark') document.body.classList.add('dark');
+}
+themeToggle.addEventListener('click',()=>{
+    document.body.classList.toggle('dark');
+    const theme=document.body.classList.contains('dark')?'dark':'light';
+    localStorage.setItem('theme',theme);
+    updateToggleText();
+});
+applyStoredTheme();
+updateToggleText();
 
 document.addEventListener('DOMContentLoaded',()=>{
     const searchInput=document.getElementById('search');

--- a/guide.html
+++ b/guide.html
@@ -28,9 +28,14 @@
             left: 0;
             right: 0;
             background-color: var(--bg-color);
-            padding: 1rem 0;
-            text-align: center;
+            padding: 1rem;
+            display: flex;
+            align-items: center;
             z-index: 1000;
+        }
+        nav {
+            flex: 1;
+            text-align: center;
         }
         nav a {
             margin: 0 0.5rem;
@@ -55,11 +60,11 @@
             <a href="guide.html">2025 Guide</a>
             <a href="eateries.html">Top Eateries</a>
         </nav>
+        <button id="theme-toggle">Dark Mode</button>
     </header>
     <main>
         <h1>2025 Guide to Chicago</h1>
         <p>Welcome to the Windy City! This brief guide will help you get settled in 2025 with tips on neighborhoods, transit, and things to see.</p>
-        <button id="theme-toggle">Dark Mode</button>
     </main>
 
     <script>

--- a/index.html
+++ b/index.html
@@ -54,9 +54,14 @@
             left: 0;
             right: 0;
             background-color: var(--bg-color);
-            padding: 1rem 0;
-            text-align: center;
+            padding: 1rem;
+            display: flex;
+            align-items: center;
             z-index: 1000;
+        }
+        nav {
+            flex: 1;
+            text-align: center;
         }
         nav a {
             margin: 0 0.5rem;
@@ -72,12 +77,12 @@
             <a href="guide.html">2025 Guide</a>
             <a href="eateries.html">Top Eateries</a>
         </nav>
+        <button id="theme-toggle">Dark Mode</button>
     </header>
     <main>
         <h1>We're moving to Chicago in:</h1>
         <div id="countdown">Loading...</div>
         <div id="weekend-count"></div>
-        <button id="theme-toggle">Dark Mode</button>
     </main>
 
     <script>


### PR DESCRIPTION
## Summary
- add flexible header and move theme toggle next to nav across pages
- style and script dark mode support for Top Eateries page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845bbec754083259eb0d8c3d6b9e743